### PR TITLE
feat: 入力チェックとファイル読込

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Allow directories to be included so we can selectively whitelist files
 !*/
+!map/*.cub
+
 
 # Whitelist important files
 !Makefile

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: kamitsui <marvin@42.fr>                    +#+  +:+       +#+         #
+#    By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 06:07:51 by kamitsui          #+#    #+#              #
-#    Updated: 2024/08/05 03:50:48 by kamitsui         ###   ########.fr        #
+#    Updated: 2024/08/08 03:01:29 by hnagasak         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -30,7 +30,7 @@ LIBMLX_DIR = $(LIB_DIR)/minilibx-linux
 
 # Source files
 SRCS = \
-       main.c
+       main.c arg_check.c debug.c
 
 #	   main.c \
 #	   draw.c \
@@ -68,11 +68,11 @@ CF_GENERATE_DEBUG_INFO = -g
 CF_INC = -I$(INC_DIR) -I$(LIBFT_DIR) -I$(LIBFTPRINTF_DIR)/includes \
 	 -I$(LIBMLX_DIR)
 CF_DEP = -MMD -MP -MF $(@:$(OBJ_DIR)/%.o=$(DEP_DIR)/%.d)
-CF_FRAMEWORK = -L$(LIBMLX_DIR) -lmlx_Linux -I$(LIBMLX_DIR) -lXext -lX11 -lm -lz
+# CF_FRAMEWORK = -L$(LIBMLX_DIR) -lmlx_Linux -I$(LIBMLX_DIR) -lXext -lX11 -lm -lz
 # To link internal Linux API
 #$(CC) $(OBJ) -Lmlx_linux -lmlx_Linux -L/usr/lib -Imlx_linux -lXext -lX11 -lm -lz -o $(NAME)
 # macOS
-#CF_FRAMEWORK = -framework OpenGL -framework AppKit
+CF_FRAMEWORK = -L./lib/minilibx-linux -lmlx -L/usr/X11R6/lib -lX11 -lXext -framework OpenGL -framework AppKit
 
 # Makefile Option
 MAKEFLAGS += --no-print-directory

--- a/includes/cub.h
+++ b/includes/cub.h
@@ -1,0 +1,68 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cub.h                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/01 03:19:09 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/08/08 04:35:25 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef CUB_H
+# define CUB_H
+
+# include "libft.h"
+
+# define MAP_WIDTH 25
+# define MAP_HEIGHT 9
+# define TILE_SIZE 30
+# define SCREEN_WIDTH 1900
+# define SCREEN_HEIGHT 1000
+# define FOV 60
+
+typedef struct
+{
+	int x, y;
+}				t_player;
+
+typedef struct s_vector
+{
+	double		x;
+	double		y;
+}				t_vector;
+
+typedef struct
+{
+	void		*mlx;
+	void		*win;
+	void		*img;
+	char		*addr;
+	int			bpp;
+	int			line_length;
+	int			endian;
+	t_player	player;
+	t_vector	pos;
+	t_vector	dir;
+	char		**map;
+	char		*cubfile;
+	char		*north;
+	char		*south;
+	char		*west;
+	char		*east;
+	int			floor;
+	int			ceiling;
+}				t_game;
+
+char			*read_cubfile(char *filepath);
+int				arg_check(int argc, char *argv[]);
+int				is_invalid_map(t_game *g);
+
+void			print_map_info(t_game *game);
+
+// utils.c
+void			*ft_free(void *ptr);
+void			free_double_pointer(char **array);
+
+#endif

--- a/map/test.cub
+++ b/map/test.cub
@@ -1,0 +1,13 @@
+NO ./textures/north_61.xpm
+SO ./textures/south_61.xpm
+WE ./textures/west_61.xpm
+EA ./textures/east_61.xpm
+
+F 46,139,87
+C 135,206,235
+
+11111
+10001
+10N01
+10001
+11111

--- a/srcs/arg_check.c
+++ b/srcs/arg_check.c
@@ -1,0 +1,356 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   arg_check.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/07/18 07:32:41 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/08/08 04:45:43 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub.h"
+#include "get_next_line.h"
+#include "libft.h"
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define EXIT_FAILURE 1
+
+#define ERRMSG_ARG_COUNT "Error:One argument must be specified\n"
+#define ERRMSG_FILE_EXT "Error:Specify a file path with .cub extension\n"
+
+/**
+ * @brief Free the memory and set the pointer to NULL.
+ * @param[in] ptr The pointer to be freed.
+ * @return NULL always.
+ */
+void	*ft_free(void *ptr)
+{
+	// printf("\t1.ft_free: %p\n", ptr);
+	if (ptr != NULL)
+		free(ptr);
+	// printf("\t2.ft_free: %p\n", ptr);
+	return (NULL);
+}
+
+void	free_double_pointer(char **array)
+{
+	int	i;
+
+	i = 0;
+	while (array[i] != NULL)
+	{
+		array[i] = ft_free(array[i]);
+		i++;
+	}
+	ft_free(array);
+}
+
+/**
+ * @brief Check the number of arguments and the file extension.
+ * @param[in] argc The number of arguments.
+ * @param[in] argv The arguments.
+ */
+int	arg_check(int argc, char *argv[])
+{
+	int		len;
+	char	*ext;
+	char	*filename;
+
+	if (argc != 2)
+	{
+		// 引き数が1つじゃない場合
+		printf(ERRMSG_ARG_COUNT);
+		return (1);
+	}
+	filename = argv[1];
+	len = ft_strlen(filename);
+	ext = &filename[len - 4];
+	if (ft_strncmp(".cub", ext, 4))
+	{
+		printf(ERRMSG_FILE_EXT);
+		return (1);
+	}
+	return (0);
+}
+
+char	*ft_strjoin_nullable(char *s1, char *s2)
+{
+	if (s1 == NULL && s2 == NULL)
+		return (NULL);
+	else if (s1 == NULL)
+		return (ft_strdup(s2));
+	else if (s2 == NULL)
+		return (ft_strdup(s1));
+	return (ft_strjoin(s1, s2));
+}
+
+char	*read_cubfile(char *filepath)
+{
+	int		fd;
+	char	*line;
+	char	*map;
+	char	*old;
+
+	old = NULL;
+	map = NULL;
+	// printf("--- read_cubfile ---\n");
+	fd = open(filepath, O_RDONLY);
+	if (fd == -1 && printf("Error: file open failed\n"))
+		return (NULL);
+	line = malloc(1);
+	while (line != NULL)
+	{
+		// printf("#### line: %p\n", line);
+		line = ft_free(line);
+		line = get_next_line(fd);
+		if (line == NULL)
+			break ;
+		if (map != NULL)
+		{
+			// printf("1: %p\n", map);
+			map = ft_free(map);
+		}
+		// printf("Line: %s\n", line);
+		map = ft_strjoin_nullable(old, line);
+		// printf("MAP %p:\n_/_/_/_/_/\n%s\n_/_/_/_/_/\n", map, map);
+		// printf("2: %p\n", old);
+		if (old != NULL)
+		{
+			// printf("2.1: %p\n", old);
+			old = ft_free(old);
+		}
+		// printf("3:map %p\n", map);
+		old = ft_strdup(map);
+		// printf("4:old %p\n", old);
+	}
+	// printf("5:%p\n", old);
+	old = ft_free(old);
+	close(fd);
+	return (map);
+}
+
+// 行末またはEOFまでの文字列をコピーする
+char	*duplicate_line(char *start)
+{
+	char	*end;
+	size_t	len;
+	char	*line;
+
+	end = ft_strchr(start, '\n');
+	if (end == NULL)
+		end = ft_strchr(start, '\0');
+	len = end - start;
+	line = ft_substr(start, 0, len);
+	return (line);
+}
+
+char	*find_element_line(char *map, char *identifier)
+{
+	char	*target;
+	char	*line;
+
+	// printf("--- find_identifier ---\n");
+	// identifierが存在するか確認
+	target = ft_strdup(identifier);
+	// 1行目が'NO ./textures/north_61.xpm'であることを確認
+	line = ft_strnstr(map, identifier, ft_strlen(map));
+	if (line == NULL)
+	{ // identifierが見つからなかった場合
+		// 2行目以降で'NO ./textures/north_61.xpm'を探す
+		target = ft_free(target);
+		target = ft_strjoin_nullable("\n", identifier);
+		line = ft_strnstr(map, identifier, ft_strlen(map));
+	}
+	if (line == NULL)
+	{
+		target = ft_free(target);
+		printf("Error: %s identifier not found\n", identifier);
+		return (NULL);
+	}
+	target = ft_free(target);
+	return (line);
+}
+
+/**
+ * @brief
+ * @param[in] map
+ * @param[in] identifier
+ * @return char* identifierが見つかった場合はその行のコピー、見つからなかった場合はNULL
+ */
+char	*get_element_line(char *map, char *identifier)
+{
+	char	*line;
+
+	line = find_element_line(map, identifier);
+	line = duplicate_line(line);
+	return (line);
+}
+
+// char *convert2path(char *line)
+char	*extract_value(char *line)
+{
+	char	*value;
+	char	**str_elm;
+	int		elm_len;
+
+	// printf("--- convert2path ---\n");
+	str_elm = ft_split(line, ' ');
+	elm_len = 0;
+	while (str_elm[elm_len] != NULL)
+		elm_len++;
+	if (elm_len != 2)
+	{
+		printf("Error: invalid identifier format\n");
+		free_double_pointer(str_elm);
+		return (NULL);
+	}
+	value = ft_strdup(str_elm[1]);
+	line = ft_free(line);
+	free_double_pointer(str_elm);
+	return (value);
+}
+
+// int rgb2hex(char *rgb)
+int	convert2color(char *rgb)
+{
+	int		color;
+	int		red;
+	int		green;
+	int		blue;
+	char	**str_elm;
+
+	str_elm = ft_split(rgb, ',');
+	red = ft_atoi(str_elm[0]);
+	green = ft_atoi(str_elm[1]);
+	blue = ft_atoi(str_elm[2]);
+	free_double_pointer(str_elm);
+	color = (red << 16) + (green << 8) + blue;
+	return (color);
+}
+
+/**
+ * @brief Check if the wall textures are set.
+ * @param[in] g t_game to set the elements
+ * @param[in] g->cubfile The map to be verified
+ * @return 1 if the wall textures are set, 0 otherwise
+ */
+int	has_elements(t_game *g)
+{
+	char	*floor_val;
+	char	*ceil_val;
+
+	// printf("--- has_wall_textures ---\n");
+	g->north = get_element_line(g->cubfile, "NO");
+	g->south = get_element_line(g->cubfile, "SO");
+	g->west = get_element_line(g->cubfile, "WE");
+	g->east = get_element_line(g->cubfile, "EA");
+	floor_val = get_element_line(g->cubfile, "F");
+	ceil_val = get_element_line(g->cubfile, "C");
+	g->north = extract_value(g->north);
+	g->south = extract_value(g->south);
+	g->west = extract_value(g->west);
+	g->east = extract_value(g->east);
+	floor_val = extract_value(floor_val);
+	ceil_val = extract_value(ceil_val);
+	g->floor = convert2color(floor_val);
+	g->ceiling = convert2color(ceil_val);
+	floor_val = ft_free(floor_val);
+	ceil_val = ft_free(ceil_val);
+	return (true);
+}
+
+// void convertStringTo2DArray(char *input, char ***array, int *numLines, int *maxLength) {
+char **convert_str2array(char *str_map) {
+    // 変数の初期化
+    int numLines = 0;
+    int maxLength = 0;
+		// int numLines;
+		int length;
+		char **array;
+
+		char **lines;
+
+		lines = ft_split(str_map, '\n');
+		// 行数と最大行長を計算
+		numLines = 0;
+		while (lines[numLines] != NULL)
+		{
+			length = ft_strlen(lines[numLines]);
+			if (length > maxLength)
+				maxLength = length;
+			numLines++;
+		}
+
+    // 配列のメモリを確保
+    array = (char **)malloc(numLines * sizeof(char *));
+    for (int i = 0; i < numLines; i++) {
+        array[i] = (char *)malloc((maxLength + 1) * sizeof(char));
+    }
+
+    // 配列に行をコピー
+    int currentLine = 0;
+		while (lines[currentLine] != NULL)
+		{
+			ft_memchr(array[currentLine], ' ', maxLength);
+			ft_strlcpy(array[currentLine], lines[currentLine], maxLength);
+			array[currentLine][maxLength] = '\0';
+			currentLine++;
+		}
+		free_double_pointer(lines);
+		return (array);
+}
+
+int	extract_map(t_game *g)
+{
+	char	*north_ln;
+	char	*south_ln;
+	char	*west_ln;
+	char	*east_ln;
+	char	*floor_ln;
+	char	*ceiling_ln;
+	char	*map_ln_1st;
+	char *str_map;
+
+	// printf("--- extract_map ---\n");
+	north_ln = find_element_line(g->cubfile, "NO");
+	south_ln = find_element_line(g->cubfile, "SO");
+	west_ln = find_element_line(g->cubfile, "WE");
+	east_ln = find_element_line(g->cubfile, "EA");
+	floor_ln = find_element_line(g->cubfile, "F");
+	ceiling_ln = find_element_line(g->cubfile, "C");
+	// TODO: 行頭が11のmap以外も探せるようにする
+	map_ln_1st = find_element_line(g->cubfile, "11");
+	// map_ln_1stが他の要素よりも前にある場合
+	if (map_ln_1st < north_ln || map_ln_1st < south_ln || map_ln_1st < west_ln
+		|| map_ln_1st < east_ln || map_ln_1st < floor_ln
+		|| map_ln_1st < ceiling_ln)
+	{
+		printf("Error: map is not at the end of the file\n");
+		// printf("map_ln_1st: %s\n", map_ln_1st);
+		return (false);
+	}
+
+	str_map = ft_strdup(map_ln_1st);
+	// printf("extract_map:\n%s\n----------\n", str_map);
+	g->map = convert_str2array(str_map);
+	ft_free(str_map);
+	return (true);
+}
+
+/**
+ * Returns 1 if it is a invalid map
+ * @param[in]  g  t_game with map to be verified
+ */
+int	is_invalid_map(t_game *g)
+{
+	// 壁のテクスチャと床天井の色が設定されているか確認
+	if (!has_elements(g))
+		return (true);
+	extract_map(g);
+	return (false);
+}

--- a/srcs/arg_check.c
+++ b/srcs/arg_check.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 07:32:41 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/08/09 22:43:49 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/08/09 23:14:44 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -350,7 +350,7 @@ char	**convert_str2array(char *str_map)
 	current_line = 0;
 	while (lines[current_line] != NULL)
 	{
-		ft_memchr(array[current_line], ' ', max_length);
+		ft_memset(array[current_line], ' ', max_length);
 		ft_strlcpy(array[current_line], lines[current_line], max_length);
 		array[current_line][max_length] = '\0';
 		current_line++;

--- a/srcs/arg_check.c
+++ b/srcs/arg_check.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 07:32:41 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/08/09 22:22:17 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/08/09 22:26:31 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -401,6 +401,7 @@ int	is_invalid_map(t_game *g)
 	// 壁のテクスチャと床天井の色が設定されているか確認
 	if (!has_elements(g))
 		return (true);
-	extract_map(g);
+	if (extract_map(g))
+		return (false);
 	return (false);
 }

--- a/srcs/arg_check.c
+++ b/srcs/arg_check.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 07:32:41 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/08/09 22:39:26 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/08/09 22:43:49 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -339,7 +339,7 @@ char	**convert_str2array(char *str_map)
 		num_lines++;
 	}
 	// 配列のメモリを確保
-	array = (char **)malloc(num_lines * sizeof(char *));
+	array = (char **)malloc((num_lines + 1) * sizeof(char *));
 	i = 0;
 	while (i < num_lines)
 	{
@@ -355,6 +355,7 @@ char	**convert_str2array(char *str_map)
 		array[current_line][max_length] = '\0';
 		current_line++;
 	}
+	array[current_line] = NULL;
 	free_double_pointer(lines);
 	return (array);
 }

--- a/srcs/arg_check.c
+++ b/srcs/arg_check.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 07:32:41 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/08/09 22:26:31 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/08/09 22:39:26 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -149,7 +149,6 @@ char	*duplicate_line(char *start)
 	return (line);
 }
 
-
 /**
  * @brief mapからidentifierが含まれる行を探す
  * @param[in] map
@@ -167,7 +166,8 @@ char	*find_element_line(char *map, char *identifier)
 	// 1行目が'NO ./textures/north_61.xpm'であることを確認
 	line = ft_strnstr(map, identifier, ft_strlen(map));
 	if (line == NULL)
-	{ // identifierが見つからなかった場合
+	{
+		// identifierが見つからなかった場合
 		// 2行目以降で'NO ./textures/north_61.xpm'を探す
 		target = ft_free(target);
 		target = ft_strjoin_nullable("\n", identifier);
@@ -203,7 +203,6 @@ char	*get_element_line(char *map, char *identifier)
 	return (line);
 }
 
-
 /**
  * @brief identifierの行から値を抽出する
  * @param[in] line
@@ -235,7 +234,6 @@ char	*extract_value(char *line, char *identifier)
 
 // int rgb2hex(char *rgb)
 
-
 /**
  * @brief Convert the RGB string to a color code.
  * @param[in] rgb The RGB string to be converted.
@@ -253,7 +251,8 @@ int	convert2color(char *rgb)
 	red = ft_atoi(str_elm[0]);
 	green = ft_atoi(str_elm[1]);
 	blue = ft_atoi(str_elm[2]);
-	if (red < 0 || red > 255 || green < 0 || green > 255 || blue < 0 || blue > 255)
+	if (red < 0 || red > 255 || green < 0 || green > 255 || blue < 0
+		|| blue > 255)
 	{
 		printf("Error: invalid color code\n");
 		free_double_pointer(str_elm);
@@ -264,22 +263,22 @@ int	convert2color(char *rgb)
 	return (color);
 }
 
-int has_textures(t_game *g)
+int	has_textures(t_game *g)
 {
 	g->north = get_element_line(g->cubfile, "NO");
 	g->south = get_element_line(g->cubfile, "SO");
 	g->west = get_element_line(g->cubfile, "WE");
 	g->east = get_element_line(g->cubfile, "EA");
-	if (g->north == NULL || g->south == NULL || g->west == NULL || g->east == NULL)
+	if (g->north == NULL || g->south == NULL || g->west == NULL
+		|| g->east == NULL)
 		return (false);
-
 	g->north = extract_value(g->north, "NO");
 	g->south = extract_value(g->south, "SO");
 	g->west = extract_value(g->west, "WE");
 	g->east = extract_value(g->east, "EA");
-	if (g->north == NULL || g->south == NULL || g->west == NULL || g->east == NULL)
+	if (g->north == NULL || g->south == NULL || g->west == NULL
+		|| g->east == NULL)
 		return (false);
-	
 	return (true);
 }
 
@@ -314,45 +313,50 @@ int	has_elements(t_game *g)
 	return (true);
 }
 
-// void convertStringTo2DArray(char *input, char ***array, int *numLines, int *maxLength) {
-char **convert_str2array(char *str_map) {
-    // 変数の初期化
-    int numLines = 0;
-    int maxLength = 0;
-		// int numLines;
-		int length;
-		char **array;
+// void convertStringTo2DArray(char *input)
+char	**convert_str2array(char *str_map)
+{
+	int		num_lines;
+	int		max_length;
+	int		length;
+	char	**array;
+	char	**lines;
+	int		current_line;
+	int		i;
 
-		char **lines;
-
-		lines = ft_split(str_map, '\n');
-		// 行数と最大行長を計算
-		numLines = 0;
-		while (lines[numLines] != NULL)
-		{
-			length = ft_strlen(lines[numLines]);
-			if (length > maxLength)
-				maxLength = length;
-			numLines++;
-		}
-
-    // 配列のメモリを確保
-    array = (char **)malloc(numLines * sizeof(char *));
-    for (int i = 0; i < numLines; i++) {
-        array[i] = (char *)malloc((maxLength + 1) * sizeof(char));
-    }
-
-    // 配列に行をコピー
-    int currentLine = 0;
-		while (lines[currentLine] != NULL)
-		{
-			ft_memchr(array[currentLine], ' ', maxLength);
-			ft_strlcpy(array[currentLine], lines[currentLine], maxLength);
-			array[currentLine][maxLength] = '\0';
-			currentLine++;
-		}
-		free_double_pointer(lines);
-		return (array);
+	// 変数の初期化
+	num_lines = 0;
+	max_length = 0;
+	// int numLines;
+	lines = ft_split(str_map, '\n');
+	// 行数と最大行長を計算
+	num_lines = 0;
+	while (lines[num_lines] != NULL)
+	{
+		length = ft_strlen(lines[num_lines]);
+		if (length > max_length)
+			max_length = length;
+		num_lines++;
+	}
+	// 配列のメモリを確保
+	array = (char **)malloc(num_lines * sizeof(char *));
+	i = 0;
+	while (i < num_lines)
+	{
+		array[i] = (char *)malloc((max_length + 1) * sizeof(char));
+		i++;
+	}
+	// 配列に行をコピー
+	current_line = 0;
+	while (lines[current_line] != NULL)
+	{
+		ft_memchr(array[current_line], ' ', max_length);
+		ft_strlcpy(array[current_line], lines[current_line], max_length);
+		array[current_line][max_length] = '\0';
+		current_line++;
+	}
+	free_double_pointer(lines);
+	return (array);
 }
 
 int	extract_map(t_game *g)
@@ -364,7 +368,7 @@ int	extract_map(t_game *g)
 	char	*floor_ln;
 	char	*ceiling_ln;
 	char	*map_ln_1st;
-	char *str_map;
+	char	*str_map;
 
 	// printf("--- extract_map ---\n");
 	north_ln = find_element_line(g->cubfile, "NO");
@@ -384,7 +388,6 @@ int	extract_map(t_game *g)
 		// printf("map_ln_1st: %s\n", map_ln_1st);
 		return (false);
 	}
-
 	str_map = ft_strdup(map_ln_1st);
 	// printf("extract_map:\n%s\n----------\n", str_map);
 	g->map = convert_str2array(str_map);

--- a/srcs/debug.c
+++ b/srcs/debug.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   debug.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/08 02:59:44 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/08/08 04:37:03 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub.h"
+#include <stdio.h>
+
+void	print_map_info(t_game *game)
+{
+	int	i;
+	printf("game->north: %s\n", game->north);
+	printf("game->south: %s\n", game->south);
+	printf("game->west: %s\n", game->west);
+	printf("game->east: %s\n", game->east);
+	printf("game->floor: %x\n", game->floor);
+	printf("game->ceiling: %x\n", game->ceiling);
+	printf("game->map:\n");
+	i = 0;
+	while (game->map[i] != NULL)
+	{
+		printf("%s\n", game->map[i]);
+		i++;
+	}
+	printf("--------------------\n");
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -2,29 +2,30 @@
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "cub.h"
 
-#define MAP_WIDTH 25
-#define MAP_HEIGHT 9
-#define TILE_SIZE 30
-#define SCREEN_WIDTH 1900
-#define SCREEN_HEIGHT 1000
-#define FOV 60
+// #define MAP_WIDTH 25
+// #define MAP_HEIGHT 9
+// #define TILE_SIZE 30
+// #define SCREEN_WIDTH 1900
+// #define SCREEN_HEIGHT 1000
+// #define FOV 60
 
-typedef struct {
-    int x, y;
-} t_player;
+// typedef struct {
+//     int x, y;
+// } t_player;
 
-typedef struct {
-    void *mlx;
-    void *win;
-    void *img;
-    char *addr;
-    int bpp;
-    int line_length;
-    int endian;
-    t_player player;
-    char *map[MAP_HEIGHT];
-} t_game;
+// typedef struct {
+//     void *mlx;
+//     void *win;
+//     void *img;
+//     char *addr;
+//     int bpp;
+//     int line_length;
+//     int endian;
+//     t_player player;
+//     char *map[MAP_HEIGHT];
+// } t_game;
 
 void my_mlx_pixel_put(t_game *game, int x, int y, int color) {
     char *dst;
@@ -121,8 +122,33 @@ void draw_walls(t_game *game) {
     }
 }
 
-int main(void) {
+int	main(int argc, char *argv[]){
     t_game game;
+
+		if (arg_check(argc, argv))
+			return (1);
+		game.cubfile = read_cubfile(argv[1]);
+		if (game.cubfile == NULL)
+		{
+			printf("Error: file read failed\n");
+			return (1);
+		}
+
+		if(is_invalid_map(&game))
+		{
+			printf("Error: invalid map\n");
+			return (1);
+		}
+		game.cubfile = ft_free(game.cubfile);
+		print_map_info(&game);
+		ft_free(game.north);
+		ft_free(game.south);
+		ft_free(game.west);
+		ft_free(game.east);
+		free_double_pointer(game.map);
+		system("leaks -q cub3D");
+		return (0);
+
 
     game.mlx = mlx_init();
     game.win = mlx_new_window(game.mlx, SCREEN_WIDTH, SCREEN_HEIGHT, "Cub3D");


### PR DESCRIPTION
## 実装内容
- 以下の引き数チェックを追加
  - 引き数の数が1つであること
  - 引き数に指定されたファイルの拡張子が.cubになっていること


- cubファイルに関する以下のチェックを追加
  - NO、SO、WE、EA、F、Cのタイプ識別子が存在すること
  - NO、SO、WE、EA、F、Cの後、空白区切りでそれぞれの情報が設定されてること
  - map情報が上記の要素より後に設定されていること

- 引き数で指定された.cubファイルを読み込んでt_gameに設定

```c
typedef struct
{
	// ...省略
	char		**map; // cubfileからmap部分だけ取り出して２次元配列に変換したもの
	char		*cubfile; // 壁、床、天井の情報も含んだ.cubファイルの内容すべて
	char		*north; // NOのテクスチャファイルのパス
	char		*south;  // SOのテクスチャファイルのパス
	char		*west;  // WEのテクスチャファイルのパス
	char		*east;  // EAのテクスチャファイルのパス
	int		floor;  // Fのカラーコード　例）2e8b57
	int		ceiling;  // Cのカラーコード 例）87ceeb
}				t_game;
```